### PR TITLE
Only use ./chrome/chrome if it is available.

### DIFF
--- a/src/Command/SitemapChecker.php
+++ b/src/Command/SitemapChecker.php
@@ -177,7 +177,8 @@ class SitemapChecker extends Command
         switch ($engine) {
           case 'chrome':
             $crawler = new ChromeCrawler();
-            $browserFactory = new BrowserFactory('./chrome/chrome');
+            $chromeBinary = is_executable('./chrome/chrome') ? './chrome/chrome' : null;
+            $browserFactory = new BrowserFactory($chromeBinary);
             $crawler->setEngine($browserFactory->createBrowser());
             break;
 


### PR DESCRIPTION
Only use `./chrome/chrome` if it is available.
If not: fallback to chrome-php/chrome's [AutoDiscover](https://github.com/chrome-php/chrome/blob/1.8/src/AutoDiscover.php#L31-L45).