### PR TITLE
Close page after checking.

### DIFF
--- a/src/Crawler/ChromeCrawler.php
+++ b/src/Crawler/ChromeCrawler.php
@@ -42,6 +42,7 @@ class ChromeCrawler extends CrawlerBase
               $result->setPageSize(mb_strlen($value));
               $result->setBody($value);
             }
+            $page->close();
         }
 
         return $result;


### PR DESCRIPTION
When checking a big sitemap, after a while there were 1000 Chromium threads running on the server.
After some testing I discovered a simple `$page->close()` prevents this problem.
