### PR TITLE
Result output improved

### DIFF
--- a/src/Command/SitemapChecker.php
+++ b/src/Command/SitemapChecker.php
@@ -213,35 +213,18 @@ class SitemapChecker extends Command
           $output->writeln('');
           $output->writeln($resultRender->render($results));
         }
-        elseif (is_string($resultFile) && str_contains($resultFile, '.csv')) {
-          $io->info('Writing CSV file.');
-          $resultRender = new CsvResultRender();
-          $renderedResult = $resultRender->render($results);
-          file_put_contents($resultFile, $renderedResult);
-        }
-        elseif (is_string($resultFile) && str_contains($resultFile, '.json')) {
-          $io->info('Writing JSON file.');
-          $resultRender = new JsonResultRender();
-          $renderedResult = $resultRender->render($results);
-          file_put_contents($resultFile, $renderedResult);
-        }
-        elseif (is_string($resultFile) && str_contains($resultFile, '.xml')) {
-          $io->info('Writing XML file.');
-          $resultRender = new XmlResultRender();
-          $renderedResult = $resultRender->render($results);
-          file_put_contents($resultFile, $renderedResult);
-        }
-        elseif (is_string($resultFile) && str_contains($resultFile, '.html')) {
-          $io->info('Writing HTML file.');
-          $resultRender = new HtmlResultRender();
-          $renderedResult = $resultRender->render($results);
-          file_put_contents($resultFile, $renderedResult);
-        }
         else {
-          $io->error('Invalid output format found.');
-          return Command::INVALID;
+            $resultExt = strtolower(pathinfo($resultFile, PATHINFO_EXTENSION));
+            $resultRender = match ($resultExt) {
+              'csv' => new CsvResultRender(),
+              'json' => new JsonResultRender(),
+              'xml' => new XmlResultRender(),
+              'html' => new HtmlResultRender(),
+              default => new PlainResultRender(),
+            };
+            $io->info(sprintf('Writing %s file.', $resultRender->getType()));
+            file_put_contents($resultFile, $resultRender->render($results));
         }
-
         return Command::SUCCESS;
     }
 

--- a/src/Command/SitemapChecker.php
+++ b/src/Command/SitemapChecker.php
@@ -204,13 +204,13 @@ class SitemapChecker extends Command
         }
 
         $progressBar->finish();
+        // We don't want to print our next output after the progress bar.
+        $output->writeln('');
 
         $resultFile = $input->getOption('result-file');
 
         if ($resultFile === NULL) {
-          // Write a blank line to print the results correctly.
           $resultRender = new PlainResultRender();
-          $output->writeln('');
           $output->writeln($resultRender->render($results));
         }
         else {

--- a/src/ResultRender/CsvResultRender.php
+++ b/src/ResultRender/CsvResultRender.php
@@ -20,5 +20,9 @@ class CsvResultRender implements ResultRenderInterface {
     return $string;
   }
 
+  public function getType(): string
+  {
+    return 'CSV';
+  }
 
 }

--- a/src/ResultRender/HtmlResultRender.php
+++ b/src/ResultRender/HtmlResultRender.php
@@ -36,5 +36,9 @@ class HtmlResultRender implements ResultRenderInterface {
 EOL;
   }
 
+  public function getType(): string
+  {
+    return 'HTML';
+  }
 
 }

--- a/src/ResultRender/JsonResultRender.php
+++ b/src/ResultRender/JsonResultRender.php
@@ -23,5 +23,9 @@ class JsonResultRender implements ResultRenderInterface {
     return json_encode($array, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK) ?: '';
   }
 
+  public function getType(): string
+  {
+    return 'JSON';
+  }
 
 }

--- a/src/ResultRender/PlainResultRender.php
+++ b/src/ResultRender/PlainResultRender.php
@@ -15,5 +15,9 @@ class PlainResultRender implements ResultRenderInterface {
     return $string;
   }
 
+  public function getType(): string
+  {
+    return 'plain';
+  }
 
 }

--- a/src/ResultRender/ResultRenderInterface.php
+++ b/src/ResultRender/ResultRenderInterface.php
@@ -6,4 +6,5 @@ use Hashbangcode\SitemapChecker\Result\ResultCollectionInterface;
 
 interface ResultRenderInterface {
   public function render(ResultCollectionInterface $resultCollection): string;
+  public function getType(): string;
 }

--- a/src/ResultRender/XmlResultRender.php
+++ b/src/ResultRender/XmlResultRender.php
@@ -22,5 +22,9 @@ class XmlResultRender implements ResultRenderInterface {
     return $xml->asXML() ?: '';
   }
 
+  public function getType(): string
+  {
+    return 'XML';
+  }
 
 }

--- a/tests/ResultRenderer/CsvResultRendererTest.php
+++ b/tests/ResultRenderer/CsvResultRendererTest.php
@@ -13,4 +13,10 @@ class CsvResultRendererTest extends ResultRendererTestBase
     $this->assertStringContainsString('"https://www.example.com/","Title","200"', $renderedResult);
   }
 
+  public function testCsvRenderReturnsType()
+  {
+    $resultRenderer = new CsvResultRender();
+    $this->assertEquals('CSV', $resultRenderer->getType());
+  }
+
 }

--- a/tests/ResultRenderer/HtmlResultRendererTest.php
+++ b/tests/ResultRenderer/HtmlResultRendererTest.php
@@ -17,4 +17,10 @@ class HtmlResultRendererTest extends ResultRendererTestBase
     $this->assertStringContainsString('<li><strong>Response Code:</strong> 200</li>', $renderedResult);
   }
 
+  public function testHtmlRenderReturnsType()
+  {
+    $resultRenderer = new HtmlResultRender();
+    $this->assertEquals('HTML', $resultRenderer->getType());
+  }
+
 }

--- a/tests/ResultRenderer/JsonResultRendererTest.php
+++ b/tests/ResultRenderer/JsonResultRendererTest.php
@@ -16,4 +16,10 @@ class JsonResultRendererTest extends ResultRendererTestBase
     $this->assertStringContainsString('"response_code":200', $renderedResult);
   }
 
+  public function testJsonRenderReturnsType()
+  {
+    $resultRenderer = new JsonResultRender();
+    $this->assertEquals('JSON', $resultRenderer->getType());
+  }
+
 }

--- a/tests/ResultRenderer/PlainResultRendererTest.php
+++ b/tests/ResultRenderer/PlainResultRendererTest.php
@@ -14,4 +14,10 @@ class PlainResultRendererTest extends ResultRendererTestBase
     $this->assertStringContainsString('https://www.example.com/ Title 200', $renderedResult);
   }
 
+  public function testPlainRenderReturnsType()
+  {
+    $resultRenderer = new PlainResultRender();
+    $this->assertEquals('plain', $resultRenderer->getType());
+  }
+
 }

--- a/tests/ResultRenderer/XmlResultRendererTest.php
+++ b/tests/ResultRenderer/XmlResultRendererTest.php
@@ -16,4 +16,10 @@ class XmlResultRendererTest extends ResultRendererTestBase
     $this->assertStringContainsString('<response_code>200</response_code>', $renderedResult);
   }
 
+  public function testXmlRenderReturnsType()
+  {
+    $resultRenderer = new XmlResultRender();
+    $this->assertEquals('XML', $resultRenderer->getType());
+  }
+
 }


### PR DESCRIPTION
The README.md [describes](https://github.com/hashbangcode/sitemap_checker/blob/main/README.md?plain=1#L36) by default you should get a 'plain' format. At least, that is how I read it 😀.
It would be logical to do this when the user specifies a `.txt` or `.log` file.
While fixing this I have refactored the ResultFile logic a bit, to remove some duplicate code.